### PR TITLE
Feature - rendering via streaming to console

### DIFF
--- a/ConsoleRenderer.Examples/ConsoleRenderer.Examples.csproj
+++ b/ConsoleRenderer.Examples/ConsoleRenderer.Examples.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/ConsoleRenderer.Examples/ConsoleRenderer.Examples.csproj
+++ b/ConsoleRenderer.Examples/ConsoleRenderer.Examples.csproj
@@ -1,8 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/ConsoleRenderer.Tests/ConsoleRenderer.Tests.csproj
+++ b/ConsoleRenderer.Tests/ConsoleRenderer.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/ConsoleRenderer.Tests/ConsoleRenderer.Tests.csproj
+++ b/ConsoleRenderer.Tests/ConsoleRenderer.Tests.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/ConsoleRenderer/ConsoleCanvas.cs
+++ b/ConsoleRenderer/ConsoleCanvas.cs
@@ -41,6 +41,8 @@ namespace ConsoleRenderer
 
         private const char _defaultCharacter = '*';
         private const char _emptyCharacter = ' ';
+        
+        private WindowsAnsi _windowsAnsi;
 
         private int _previousWidth;
         private int _previousHeight;
@@ -48,8 +50,10 @@ namespace ConsoleRenderer
         private Pixel[] _pixels;
         private Pixel[] _previous;
         
-        /// <summary>Shared across all instances so that every canvas renders to the same console output.</summary>
-        private static Stream? _outputStream;
+        /// <summary>
+        ///     Shared across all instances so that every canvas renders to the same console output.
+        /// </summary>
+        private Stream? _outputStream;
         private ArrayBufferWriter<byte>? _frameBuffer;
         private static bool _ansiInitialized;
 
@@ -70,6 +74,7 @@ namespace ConsoleRenderer
 
             _pixels = new Pixel[Width * Height];
             _previous = new Pixel[Width * Height];
+            _windowsAnsi = new WindowsAnsi();
 
             Resize(width, height);
         }
@@ -307,7 +312,7 @@ namespace ConsoleRenderer
                         lastBg = bg;
                     }
 
-                    WriteUtf8Char(buffer, p.Character);
+                    WriteEncodedChar(buffer, p.Character);
                 }
 
                 // Newline between rows only; skipping after last row prevents terminal scroll (first line cut off)
@@ -524,6 +529,16 @@ namespace ConsoleRenderer
             return backBuffer ? _previous[index] : _pixels[index];
         }
 
+        /// <summary>
+        ///     Set encoding of the console output (defaults to UTF-8).
+        /// </summary>
+        /// <param name="encoding">Encoding of the console output including ANSI codes.</param>
+        public void SetOutputEncoding(Encoding encoding)
+        {
+            // This will trigger a re-initialisation of the Windows ANSI support during the render call.
+            _windowsAnsi = new WindowsAnsi(encoding);
+        }
+        
         private void ClearPixelCache()
         {
             var defaultPixel = new Pixel
@@ -544,15 +559,8 @@ namespace ConsoleRenderer
 
             lock (typeof(ConsoleCanvas))
             {
-                if (!_ansiInitialized)
-                {
-                    // Windows needs VT mode for ANSI; Linux and macOS terminals already support it
-                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                        WindowsAnsiHelper.EnableVirtualTerminalProcessing();
-                    Console.OutputEncoding = Encoding.UTF8;
-                    _ansiInitialized = true;
-                }
-
+                _windowsAnsi.EnsureAnsiSupport();
+                
                 if (_outputStream == null)
                     _outputStream = Console.OpenStandardOutput();
 
@@ -584,36 +592,12 @@ namespace ConsoleRenderer
             buffer.Write("m"u8);
         }
 
-        private static void WriteUtf8Char(ArrayBufferWriter<byte> buffer, char c)
+        private static void WriteEncodedChar(ArrayBufferWriter<byte> buffer, char c)
         {
             Span<char> cSpan = stackalloc char[1] { c };
             Span<byte> dest = buffer.GetSpan(4);
-            int written = Encoding.UTF8.GetBytes(cSpan, dest);
+            int written = Console.OutputEncoding.GetBytes(cSpan, dest);
             buffer.Advance(written);
-        }
-
-        private static class WindowsAnsiHelper
-        {
-            private const int StdOutputHandle = -11;
-            private const uint VirtualTerminalProcessingFlag = 0x0004;
-
-            public static void EnableVirtualTerminalProcessing()
-            {
-                var handle = GetStdHandle(StdOutputHandle);
-                if (handle != IntPtr.Zero && GetConsoleMode(handle, out uint mode))
-                {
-                    SetConsoleMode(handle, mode | VirtualTerminalProcessingFlag);
-                }
-            }
-
-            [DllImport("kernel32")]
-            private static extern IntPtr GetStdHandle(int nStdHandle);
-
-            [DllImport("kernel32")]
-            private static extern bool GetConsoleMode(IntPtr hConsoleHandle, out uint lpMode);
-
-            [DllImport("kernel32")]
-            private static extern bool SetConsoleMode(IntPtr hConsoleHandle, uint dwMode);
         }
     }
 }

--- a/ConsoleRenderer/ConsoleCanvas.cs
+++ b/ConsoleRenderer/ConsoleCanvas.cs
@@ -45,8 +45,10 @@ namespace ConsoleRenderer
         private int _previousWidth;
         private int _previousHeight;
         private bool _oddRows;
-        private List<List<Pixel>> _pixels;
-        private List<List<Pixel>> _previous;
+        private Pixel[] _pixels;
+        private Pixel[] _previous;
+        
+        /// <summary>Shared across all instances so that every canvas renders to the same console output.</summary>
         private static Stream? _outputStream;
         private ArrayBufferWriter<byte>? _frameBuffer;
         private static bool _ansiInitialized;
@@ -66,8 +68,8 @@ namespace ConsoleRenderer
             if ((int)DefaultForegroundColor == -1) DefaultForegroundColor = ConsoleColor.Gray;
             if ((int)DefaultBackgroundColor == -1) DefaultBackgroundColor = ConsoleColor.Black;
 
-            _pixels = new List<List<Pixel>>();
-            _previous = new List<List<Pixel>>();
+            _pixels = new Pixel[Width * Height];
+            _previous = new Pixel[Width * Height];
 
             Resize(width, height);
         }
@@ -95,9 +97,14 @@ namespace ConsoleRenderer
         /// <returns></returns>
         public ConsoleCanvas Fill(char character, ConsoleColor foreground, ConsoleColor background)
         {
-            for (int y = 0; y < Height; y++)
-                for (int x = 0; x < Width; x++)
-                    Set(x, y, character, foreground, background);
+            var pixel = new Pixel
+            {
+                Character = character,
+                Foreground = foreground,
+                Background = background
+            };
+            for (int i = 0; i < _pixels.Length; i++)
+                _pixels[i] = pixel;
 
             return this;
         }
@@ -148,57 +155,56 @@ namespace ConsoleRenderer
         /// <returns></returns>
         public ConsoleCanvas CreateBorder(int startX, int startY, int width, int height, char? character, ConsoleColor foreground, ConsoleColor background)
         {
-            for (int y = startY; y < startY + height; y++)
+            int endX = startX + width - 1;
+            int endY = startY + height - 1;
+
+            var pixel = new Pixel
             {
-                for (int x = startX; x < startX + width; x++)
+                Foreground = foreground,
+                Background = background,
+                Character = character ?? _emptyCharacter
+            };
+
+            for (int y = startY; y <= endY && y < Height; y++)
+            {
+                for (int x = startX; x <= endX && x < Width; x++)
                 {
-                    if ( y != startY && y + 1 != startY + height && x != startX && x + 1 != startX + width)
-                    {
+                    bool onTop = y == startY;
+                    bool onBottom = y == endY;
+                    bool onLeft = x == startX;
+                    bool onRight = x == endX;
+                    if (!onTop && !onBottom && !onLeft && !onRight)
                         continue;
-                    }
 
-                    char fallback = ' ';
-                    if ( y == startY )
-                    {
-                        if ( x == startX )
-                        {
-                            fallback = '╔';
-                        }
-                        else if ( x + 1 == startX + width)
-                        {
-                            fallback = '╗';
-                        }
-                        else
-                        {
-                            fallback = '═';
-                        }
-                        
-                    }
-                    else if (y + 1 == startY + height)
-                    {
-                        if (x == startX)
-                        {
-                            fallback = '╚';
-                        }
-                        else if (x + 1 == startX + width)
-                        {
-                            fallback = '╝';
-                        }
-                        else
-                        {
-                            fallback = '═';
-                        }
-                    }
-                    else if (x == startX || x + 1 == startX + width)
-                    {
-                        fallback = '║';
-                    }
-
-                    Set(x, y, character ?? fallback, foreground, background);
+                    pixel.Character = character ?? GetBorderChar(x, y, startX, startY, endX, endY);
+                    _pixels[y * Width + x] = pixel;
                 }
             }
 
             return this;
+        }
+
+        private static char GetBorderChar(int x, int y, int startX, int startY, int endX, int endY)
+        {
+            bool onTop = y == startY;
+            bool onBottom = y == endY;
+            bool onLeft = x == startX;
+            bool onRight = x == endX;
+
+            if (onTop)
+            {
+                if (onLeft) return '╔';
+                if (onRight) return '╗';
+                return '═';
+            }
+            if (onBottom)
+            {
+                if (onLeft) return '╚';
+                if (onRight) return '╝';
+                return '═';
+            }
+            if (onLeft || onRight) return '║';
+            return _emptyCharacter;
         }
 
         /// <summary>
@@ -226,10 +232,22 @@ namespace ConsoleRenderer
         /// <param name="background">Color to draw the background with</param>
         public ConsoleCanvas CreateRectangle(int startX, int startY, int width, int height, char character, ConsoleColor foreground, ConsoleColor background)
         {
-            for (int y = startY; y < Height && y-startY < height; y++)
+            int yMin = Math.Max(0, startY);
+            int yMax = Math.Min(Height, startY + height);
+            int xMin = Math.Max(0, startX);
+            int xMax = Math.Min(Width, startX + width);
+            var pixel = new Pixel
             {
-                for (int x = startX; x < Width && x - startX < width; x++)
-                    Set(x, y, character, foreground, background);
+                Character = character,
+                Foreground = foreground,
+                Background = background
+            };
+
+            for (int y = yMin; y < yMax; y++)
+            {
+                int rowStart = y * Width;
+                for (int x = xMin; x < xMax; x++)
+                    _pixels[rowStart + x] = pixel;
             }
 
             return this;
@@ -273,11 +291,11 @@ namespace ConsoleRenderer
             for (int y = 0; y < effectiveHeight; y++)
             {
                 bool skipRow = Interlaced && ((_oddRows && y % 2 == 0) || (!_oddRows && y % 2 != 0));
-                List<Pixel> sourceRow = skipRow ? _previous[y] : _pixels[y];
+                ReadOnlySpan<Pixel> source = skipRow ? _previous : _pixels;
 
                 for (int x = 0; x < effectiveWidth; x++)
                 {
-                    Pixel p = sourceRow[x];
+                    Pixel p = source[y * Width + x];
                     int fg = AnsiForeground[(int)p.Foreground];
                     int bg = AnsiBackground[(int)p.Background];
 
@@ -295,18 +313,21 @@ namespace ConsoleRenderer
                 // Newline between rows only; skipping after last row prevents terminal scroll (first line cut off)
                 if (y < effectiveHeight - 1)
                     buffer.Write("\n"u8);
+                
                 lastFg = -1;
                 lastBg = -1;
 
                 if (!skipRow)
                 {
+                    int rowStart = y * Width;
                     for (int x = 0; x < Width; x++)
-                        _previous[y][x] = sourceRow[x];
+                        _previous[rowStart + x] = source[rowStart + x];
                 }
             }
 
+            // Cursor to top-left (1-based in ANSI)
             buffer.Write("\x1b[1;1H"u8);
-
+            
             _outputStream!.Write(buffer.WrittenSpan);
             _outputStream.Flush();
 
@@ -324,29 +345,18 @@ namespace ConsoleRenderer
         {
             Width = width;
             Height = height;
-            _pixels = new List<List<Pixel>>();
-            _previous = new List<List<Pixel>>();
+            _pixels = new Pixel[Width * Height];
+            _previous = new Pixel[Width * Height];
 
-            for (int y = 0; y < Height; y++)
+            var defaultPixel = new Pixel
             {
-                var row = new List<Pixel>();
-                var previousRow = new List<Pixel>();
-                for (int x = 0; x < Width; x++)
-                {
-                    var pixel = new Pixel
-                    {
-                        Character = _emptyCharacter,
-                        Foreground = DefaultForegroundColor,
-                        Background = DefaultBackgroundColor
-                    };
+                Background = DefaultBackgroundColor,
+                Foreground = DefaultForegroundColor,
+                Character = _emptyCharacter
+            };
 
-                    row.Add(pixel);
-                    previousRow.Add(pixel);
-                }
-
-                _pixels.Add(row);
-                _previous.Add(previousRow);
-            }
+            Array.Fill(_pixels, defaultPixel);
+            Array.Fill(_previous, defaultPixel);
 
             return this;
         }
@@ -413,7 +423,7 @@ namespace ConsoleRenderer
         public ConsoleCanvas Set(int x, int y, Pixel pixel)
         {
             if (x >= 0 && x < Width && y >= 0 && y < Height)
-                _pixels[y][x] = pixel;
+                _pixels[y * Width + x] = pixel;
 
             return this;
         }
@@ -427,10 +437,15 @@ namespace ConsoleRenderer
         /// <param name="pixels">Pixels to set at the specified coordinates</param>
         public ConsoleCanvas Set(int x, int y, Pixel[] pixels)
         {
-            for (int t = 0; t < pixels.Length; t++)
-            {
-                Set(x+t, y, pixels[t]);
-            }
+            if (y < 0 || y >= Height || pixels.Length == 0)
+                return this;
+            int start = Math.Max(0, -x);
+            int count = Math.Min(pixels.Length - start, Width - (x + start));
+            if (count <= 0)
+                return this;
+            int rowStart = y * Width;
+            for (int i = 0; i < count; i++)
+                _pixels[rowStart + x + start + i] = pixels[start + i];
 
             return this;
         }
@@ -444,10 +459,15 @@ namespace ConsoleRenderer
         /// <param name="pixels">Pixels to set at the specified coordinates</param>
         public ConsoleCanvas Set(int x, int y, List<Pixel> pixels)
         {
-            for (int t = 0; t < pixels.Count; t++)
-            {
-                Set(x + t, y, pixels[t]);
-            }
+            if (y < 0 || y >= Height || pixels.Count == 0)
+                return this;
+            int start = Math.Max(0, -x);
+            int count = Math.Min(pixels.Count - start, Width - (x + start));
+            if (count <= 0)
+                return this;
+            int rowStart = y * Width;
+            for (int i = 0; i < count; i++)
+                _pixels[rowStart + x + start + i] = pixels[start + i];
 
             return this;
         }
@@ -464,16 +484,22 @@ namespace ConsoleRenderer
         public ConsoleCanvas Text(int x, int y, string text, bool centered = false, ConsoleColor? foreground = null, ConsoleColor? background = null)
         {
             // If the text should be centered, deduct half the text length from the x coordinate
-            int startX = centered ? x - (int) Math.Floor(text.Length/2d) : x;
+            int startX = centered ? x - (int)Math.Floor(text.Length / 2d) : x;
+            var fg = foreground ?? DefaultForegroundColor;
+            var bg = background ?? DefaultBackgroundColor;
 
-            for (int t = 0; t < text.Length && t < Width; t++)
+            if (y < 0 || y >= Height)
+                return this;
+            int rowStart = y * Width;
+            var pixel = new Pixel { Foreground = fg, Background = bg };
+            for (int t = 0; t < text.Length; t++)
             {
-                Set(startX + t, y, new Pixel
+                int px = startX + t;
+                if (px >= 0 && px < Width)
                 {
-                    Character = text[t],
-                    Foreground = foreground ?? DefaultForegroundColor,
-                    Background = background ?? DefaultBackgroundColor
-                });
+                    pixel.Character = text[t];
+                    _pixels[rowStart + px] = pixel;
+                }
             }
 
             return this;
@@ -482,6 +508,8 @@ namespace ConsoleRenderer
         /// <summary>
         /// Returns the <see cref="Pixel"/> at the given <paramref name="x"/>,<paramref name="y"/> coordinates
         /// </summary>
+        /// <param name="x"></param>
+        /// <param name="y"></param>
         /// <param name="backBuffer">Whether to return the pixel as it was last drawn (<see cref="true"/>), or the
         /// one that will be drawn at the next call to <see cref="Render"/></param>
         /// <exception cref="IndexOutOfRangeException"></exception>
@@ -492,7 +520,8 @@ namespace ConsoleRenderer
                 throw new IndexOutOfRangeException($"The coordinates {x},{y} need to be positive and less than {Width} and {Height}");
             }
 
-            return backBuffer ? _previous[y][x] : _pixels[y][x];
+            int index = y * Width + x;
+            return backBuffer ? _previous[index] : _pixels[index];
         }
 
         private void ClearPixelCache()
@@ -501,12 +530,11 @@ namespace ConsoleRenderer
             {
                 Background = DefaultBackgroundColor,
                 Foreground = DefaultForegroundColor,
-                Character = '\u00A0'
+                Character = _emptyCharacter
             };
 
-            for (int y = 0; y < Height; y++)
-                for (int x = 0; x < Width; x++)
-                    _previous[y][x] = defaultPixel;
+            for (int i = 0; i < _previous.Length; i++)
+                _previous[i] = defaultPixel;
         }
 
         private void EnsureStreamInitialized()
@@ -554,11 +582,6 @@ namespace ConsoleRenderer
                 buffer.Write(stackalloc byte[] { (byte)('0' + code) });
             }
             buffer.Write("m"u8);
-        }
-
-        private static void WriteSgrReset(ArrayBufferWriter<byte> buffer)
-        {
-            buffer.Write("\x1b[0m"u8);
         }
 
         private static void WriteUtf8Char(ArrayBufferWriter<byte> buffer, char c)

--- a/ConsoleRenderer/ConsoleCanvas.cs
+++ b/ConsoleRenderer/ConsoleCanvas.cs
@@ -42,8 +42,6 @@ namespace ConsoleRenderer
         private const char _defaultCharacter = '*';
         private const char _emptyCharacter = ' ';
         
-        private WindowsAnsi _windowsAnsi;
-
         private int _previousWidth;
         private int _previousHeight;
         private bool _oddRows;
@@ -74,7 +72,6 @@ namespace ConsoleRenderer
 
             _pixels = new Pixel[Width * Height];
             _previous = new Pixel[Width * Height];
-            _windowsAnsi = new WindowsAnsi();
 
             Resize(width, height);
         }
@@ -529,16 +526,6 @@ namespace ConsoleRenderer
             return backBuffer ? _previous[index] : _pixels[index];
         }
 
-        /// <summary>
-        ///     Set encoding of the console output (defaults to UTF-8).
-        /// </summary>
-        /// <param name="encoding">Encoding of the console output including ANSI codes.</param>
-        public void SetOutputEncoding(Encoding encoding)
-        {
-            // This will trigger a re-initialisation of the Windows ANSI support during the render call.
-            _windowsAnsi = new WindowsAnsi(encoding);
-        }
-        
         private void ClearPixelCache()
         {
             var defaultPixel = new Pixel
@@ -559,7 +546,7 @@ namespace ConsoleRenderer
 
             lock (typeof(ConsoleCanvas))
             {
-                _windowsAnsi.EnsureAnsiSupport();
+                WindowsAnsi.EnsureAnsiSupport();
                 
                 if (_outputStream == null)
                     _outputStream = Console.OpenStandardOutput();

--- a/ConsoleRenderer/ConsoleCanvas.cs
+++ b/ConsoleRenderer/ConsoleCanvas.cs
@@ -1,5 +1,9 @@
-﻿using System;
+using System;
+using System.Buffers;
 using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
 
 namespace ConsoleRenderer
 {
@@ -43,6 +47,9 @@ namespace ConsoleRenderer
         private bool _oddRows;
         private List<List<Pixel>> _pixels;
         private List<List<Pixel>> _previous;
+        private static Stream? _outputStream;
+        private ArrayBufferWriter<byte>? _frameBuffer;
+        private static bool _ansiInitialized;
 
         public ConsoleCanvas(int width, int height, bool interlaced = false, bool autoResize = false)
         {
@@ -53,6 +60,11 @@ namespace ConsoleRenderer
 
             DefaultForegroundColor = Console.ForegroundColor;
             DefaultBackgroundColor = Console.BackgroundColor;
+            
+            // In Linux Console.ForegroundColor is sometimes not defined (-1).
+            // In that case set it manually.
+            if ((int)DefaultForegroundColor == -1) DefaultForegroundColor = ConsoleColor.Gray;
+            if ((int)DefaultBackgroundColor == -1) DefaultBackgroundColor = ConsoleColor.Black;
 
             _pixels = new List<List<Pixel>>();
             _previous = new List<List<Pixel>>();
@@ -228,20 +240,14 @@ namespace ConsoleRenderer
         /// </summary>
         public ConsoleCanvas Render()
         {
-            Console.CursorTop = 0;
-            Console.CursorLeft = 0;
+            EnsureStreamInitialized();
 
-            // Temporary variables to track Console attributes like size, position and color
-            int cursorTop = 0;
-            int cursorLeft = 0;
             int windowWidth = Console.WindowWidth;
             int windowHeight = Console.WindowHeight;
-            ConsoleColor foregroundColor = Console.ForegroundColor;
-            ConsoleColor backgroundColor = Console.BackgroundColor;
 
             if (_previousWidth != windowWidth || _previousHeight != windowHeight)
             {
-                if ( AutoResize )
+                if (AutoResize)
                 {
                     Resize(windowWidth, windowHeight);
                 }
@@ -252,86 +258,58 @@ namespace ConsoleRenderer
                 _previousHeight = windowHeight;
             }
 
-            int leftOperations = 0;
-            int backgroundOperations = 0;
+            int effectiveWidth = Math.Min(Width, windowWidth);
+            int effectiveHeight = Math.Min(Height, windowHeight);
 
-            for (int y = 0; y < Height; y++)
+            ArrayBufferWriter<byte> buffer = _frameBuffer!;
+            buffer.Clear();
+
+            // Cursor to top-left (1-based in ANSI)
+            buffer.Write("\x1b[1;1H"u8);
+
+            int lastFg = -1;
+            int lastBg = -1;
+
+            for (int y = 0; y < effectiveHeight; y++)
             {
-                // See if this is one of the rows we should skip in Interlaced mode
-                if ( Interlaced && ((_oddRows && y % 2 == 0) || (!_oddRows && y % 2 != 0)) )
-                    continue;
+                bool skipRow = Interlaced && ((_oddRows && y % 2 == 0) || (!_oddRows && y % 2 != 0));
+                List<Pixel> sourceRow = skipRow ? _previous[y] : _pixels[y];
 
-                for (int x = 0; x < Width; x++)
-                {                        
-                    if (_pixels[y][x] == _previous[y][x])
-                        continue;
+                for (int x = 0; x < effectiveWidth; x++)
+                {
+                    Pixel p = sourceRow[x];
+                    int fg = AnsiForeground[(int)p.Foreground];
+                    int bg = AnsiBackground[(int)p.Background];
 
-                    if (x >= windowWidth)
-                        continue;
-
-                    if (y >= windowHeight)
-                        continue;
-
-                    if (cursorLeft != x)
+                    if (fg != lastFg || bg != lastBg)
                     {
-                        try
-                        {
-                            Console.CursorLeft = x;
-                        }
-                        catch (ArgumentOutOfRangeException)
-                        {
-                            return Render();
-                        }
-
-                        cursorLeft = x;
-                        leftOperations++;
+                        WriteSgr(buffer, fg);
+                        WriteSgr(buffer, bg);
+                        lastFg = fg;
+                        lastBg = bg;
                     }
 
-                    if (cursorTop != y)
-                    {
-                        try
-                        {
-                            Console.CursorTop = y;
-                        }
-                        catch (ArgumentOutOfRangeException)
-                        {
-                            return Render();
-                        }
+                    WriteUtf8Char(buffer, p.Character);
+                }
 
-                        cursorTop = y;
-                    }
+                // Newline between rows only; skipping after last row prevents terminal scroll (first line cut off)
+                if (y < effectiveHeight - 1)
+                    buffer.Write("\n"u8);
+                lastFg = -1;
+                lastBg = -1;
 
-                    if (_pixels[y][x].Character != ' ' && _pixels[y][x].Foreground != foregroundColor)
-                    {
-                        Console.ForegroundColor = _pixels[y][x].Foreground;
-                        foregroundColor = _pixels[y][x].Foreground;
-                    }
-
-                    if (_pixels[y][x].Background != backgroundColor)
-                    {
-                        Console.BackgroundColor = _pixels[y][x].Background;
-                        backgroundColor = _pixels[y][x].Background;
-                        backgroundOperations++;
-                    }
-
-                    Console.Write(_pixels[y][x].Character);
-                    cursorLeft++;
-
-                    _previous[y][x] = _pixels[y][x];
-
-                    // After writing the last character on the bottom right, reposition the cursor to prevent
-                    // an unintended newline, which may shift the screen downwards, causing jitter
-                    if ( cursorLeft == windowWidth && cursorTop == windowHeight - 1)
-                    {
-                        Console.CursorLeft = 0;
-                        Console.CursorTop = 0;
-                        cursorLeft = 0;
-                        cursorTop = 0;
-                    }
+                if (!skipRow)
+                {
+                    for (int x = 0; x < Width; x++)
+                        _previous[y][x] = sourceRow[x];
                 }
             }
 
-            // Swap whether we render odd or even rows next frame
+            buffer.Write("\x1b[1;1H"u8);
+
+            _outputStream!.Write(buffer.WrittenSpan);
+            _outputStream.Flush();
+
             _oddRows = !_oddRows;
             return this;
         }
@@ -529,6 +507,90 @@ namespace ConsoleRenderer
             for (int y = 0; y < Height; y++)
                 for (int x = 0; x < Width; x++)
                     _previous[y][x] = defaultPixel;
+        }
+
+        private void EnsureStreamInitialized()
+        {
+            if (_outputStream != null && _frameBuffer != null)
+                return;
+
+            lock (typeof(ConsoleCanvas))
+            {
+                if (!_ansiInitialized)
+                {
+                    // Windows needs VT mode for ANSI; Linux and macOS terminals already support it
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                        WindowsAnsiHelper.EnableVirtualTerminalProcessing();
+                    Console.OutputEncoding = Encoding.UTF8;
+                    _ansiInitialized = true;
+                }
+
+                if (_outputStream == null)
+                    _outputStream = Console.OpenStandardOutput();
+
+                if (_frameBuffer == null)
+                    _frameBuffer = new ArrayBufferWriter<byte>();
+            }
+        }
+
+        // ANSI SGR codes for ConsoleColor (index = (int)ConsoleColor): 30-37, 90-97 fg; 40-47, 100-107 bg
+        private static readonly int[] AnsiForeground = { 30, 34, 32, 36, 31, 35, 33, 37, 90, 94, 92, 96, 91, 95, 93, 97 };
+        private static readonly int[] AnsiBackground = { 40, 44, 42, 46, 41, 45, 43, 47, 100, 104, 102, 106, 101, 105, 103, 107 };
+
+        private static void WriteSgr(ArrayBufferWriter<byte> buffer, int code)
+        {
+            buffer.Write("\x1b["u8);
+            if (code >= 100)
+            {
+                buffer.Write("1"u8);
+                buffer.Write(stackalloc byte[] { (byte)('0' + (code / 10 % 10)), (byte)('0' + (code % 10)) });
+            }
+            else if (code >= 10)
+            {
+                buffer.Write(stackalloc byte[] { (byte)('0' + (code / 10)), (byte)('0' + (code % 10)) });
+            }
+            else
+            {
+                buffer.Write(stackalloc byte[] { (byte)('0' + code) });
+            }
+            buffer.Write("m"u8);
+        }
+
+        private static void WriteSgrReset(ArrayBufferWriter<byte> buffer)
+        {
+            buffer.Write("\x1b[0m"u8);
+        }
+
+        private static void WriteUtf8Char(ArrayBufferWriter<byte> buffer, char c)
+        {
+            Span<char> cSpan = stackalloc char[1] { c };
+            Span<byte> dest = buffer.GetSpan(4);
+            int written = Encoding.UTF8.GetBytes(cSpan, dest);
+            buffer.Advance(written);
+        }
+
+        private static class WindowsAnsiHelper
+        {
+            private const int StdOutputHandle = -11;
+            private const uint VirtualTerminalProcessingFlag = 0x0004;
+
+            public static void EnableVirtualTerminalProcessing()
+            {
+                var handle = GetStdHandle(StdOutputHandle);
+                if (handle != IntPtr.Zero && GetConsoleMode(handle, out uint mode))
+                {
+                    SetConsoleMode(handle, mode | VirtualTerminalProcessingFlag);
+                }
+            }
+
+            [DllImport("kernel32")]
+            private static extern IntPtr GetStdHandle(int nStdHandle);
+
+            [DllImport("kernel32")]
+            private static extern bool GetConsoleMode(IntPtr hConsoleHandle, out uint lpMode);
+
+            [DllImport("kernel32")]
+            private static extern bool SetConsoleMode(IntPtr hConsoleHandle, uint dwMode);
         }
     }
 }

--- a/ConsoleRenderer/ConsoleCanvas.cs
+++ b/ConsoleRenderer/ConsoleCanvas.cs
@@ -2,8 +2,6 @@ using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.InteropServices;
-using System.Text;
 
 namespace ConsoleRenderer
 {
@@ -53,7 +51,6 @@ namespace ConsoleRenderer
         /// </summary>
         private Stream? _outputStream;
         private ArrayBufferWriter<byte>? _frameBuffer;
-        private static bool _ansiInitialized;
 
         public ConsoleCanvas(int width, int height, bool interlaced = false, bool autoResize = false)
         {
@@ -544,16 +541,13 @@ namespace ConsoleRenderer
             if (_outputStream != null && _frameBuffer != null)
                 return;
 
-            lock (typeof(ConsoleCanvas))
-            {
-                WindowsAnsi.EnsureAnsiSupport();
+            WindowsAnsi.EnsureAnsiSupport();
                 
-                if (_outputStream == null)
-                    _outputStream = Console.OpenStandardOutput();
+            if (_outputStream == null)
+                _outputStream = Console.OpenStandardOutput();
 
-                if (_frameBuffer == null)
-                    _frameBuffer = new ArrayBufferWriter<byte>();
-            }
+            if (_frameBuffer == null)
+                _frameBuffer = new ArrayBufferWriter<byte>();
         }
 
         // ANSI SGR codes for ConsoleColor (index = (int)ConsoleColor): 30-37, 90-97 fg; 40-47, 100-107 bg

--- a/ConsoleRenderer/ConsoleRenderer.csproj
+++ b/ConsoleRenderer/ConsoleRenderer.csproj
@@ -5,7 +5,7 @@
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
-	  <Version>0.7.1</Version>
+    <Version>0.8.0</Version>
 	  <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 	  <Title>ConsoleRenderer</Title>
 	  <Authors>NinovdMark</Authors>

--- a/ConsoleRenderer/ConsoleRenderer.csproj
+++ b/ConsoleRenderer/ConsoleRenderer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/ConsoleRenderer/ConsoleRenderer.csproj
+++ b/ConsoleRenderer/ConsoleRenderer.csproj
@@ -1,7 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	  <Version>0.7.1</Version>

--- a/ConsoleRenderer/WindowsAnsi.cs
+++ b/ConsoleRenderer/WindowsAnsi.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace ConsoleRenderer;
 

--- a/ConsoleRenderer/WindowsAnsi.cs
+++ b/ConsoleRenderer/WindowsAnsi.cs
@@ -4,25 +4,16 @@ using System.Text;
 
 namespace ConsoleRenderer;
 
-internal class WindowsAnsi
+internal static class WindowsAnsi
 {
     
     private const int StdOutputHandle = -11;
     private const uint VirtualTerminalProcessingFlag = 0x0004;
 
-    private readonly Encoding _outputEncoding;
-    private bool _isAnsiInitialized;
-
-    internal WindowsAnsi(): this(Encoding.UTF8)
-    {
-    }
+    private static bool _isAnsiInitialized;
     
-    internal WindowsAnsi(Encoding outputEncoding)
-    {
-        _outputEncoding = outputEncoding;
-    }
 
-    internal void EnsureAnsiSupport()
+    internal static void EnsureAnsiSupport()
     {
         if (_isAnsiInitialized) return;
         
@@ -30,7 +21,6 @@ internal class WindowsAnsi
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             EnableVirtualTerminalProcessing();
 
-        Console.OutputEncoding = _outputEncoding;
         _isAnsiInitialized = true;
     }
 

--- a/ConsoleRenderer/WindowsAnsi.cs
+++ b/ConsoleRenderer/WindowsAnsi.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace ConsoleRenderer;
+
+internal class WindowsAnsi
+{
+    
+    private const int StdOutputHandle = -11;
+    private const uint VirtualTerminalProcessingFlag = 0x0004;
+
+    private readonly Encoding _outputEncoding;
+    private bool _isAnsiInitialized;
+
+    internal WindowsAnsi(): this(Encoding.UTF8)
+    {
+    }
+    
+    internal WindowsAnsi(Encoding outputEncoding)
+    {
+        _outputEncoding = outputEncoding;
+    }
+
+    internal void EnsureAnsiSupport()
+    {
+        if (_isAnsiInitialized) return;
+        
+        // Windows needs VT mode for ANSI; Linux and macOS terminals already support it
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            EnableVirtualTerminalProcessing();
+
+        Console.OutputEncoding = _outputEncoding;
+        _isAnsiInitialized = true;
+    }
+
+    private static void EnableVirtualTerminalProcessing()
+    {
+        var handle = GetStdHandle(StdOutputHandle);
+        if (handle != IntPtr.Zero && GetConsoleMode(handle, out var mode))
+        {
+            SetConsoleMode(handle, mode | VirtualTerminalProcessingFlag);
+        }
+    }
+
+    [DllImport("kernel32")]
+    private static extern IntPtr GetStdHandle(int nStdHandle);
+
+    [DllImport("kernel32")]
+    private static extern bool GetConsoleMode(IntPtr hConsoleHandle, out uint lpMode);
+
+    [DllImport("kernel32")]
+    private static extern bool SetConsoleMode(IntPtr hConsoleHandle, uint dwMode);
+}


### PR DESCRIPTION
# Rendering Via Streaming to Console

I came across the issue https://github.com/NinovanderMark/ConsoleRenderer/issues/10 and wanted to give this idea a try.

## Results

It turns out streaming works really well and improves performance at least by an order of magnitude on windows.
On my Linux machine the gains are not quite as good (17 fps -> 57 fps for the colornoise example) but at least still an improvement.

Update: I switched from Alacritty to Kitty and now the performance is equally good to Windows (~350 fps for colornoise). Seems to have been an issue with the terminal emulator.

## Platform-Independence

This code runs without issues on Windows and Linux (tested on physical machines) so I'd expect the same on Mac, but don't have the hardware to test.

## Dotnet 6 -> 10 ?

This change also includes an upgrade of dotnet to version 10 in the first commit of this PR. If you want to stay on dotnet 6 then I can cherry-pick the other commits to exclude the version upgrade. Some minor changes would be needed from using some dotnet 7+ features, but nothing major.