### PR TITLE
Feature - Clustered Rendering

### DIFF
--- a/ConsoleRenderer/ConsoleCanvas.cs
+++ b/ConsoleRenderer/ConsoleCanvas.cs
@@ -591,22 +591,11 @@ namespace ConsoleRenderer
             return currentX;
         }
 
-        private void MoveCursorAnsi(int x, int y, in ArrayBufferWriter<byte> buffer)
+        private static void MoveCursorAnsi(int x, int y, in ArrayBufferWriter<byte> buffer)
         {
             Span<byte> ansiBuffer = stackalloc byte[32];
-            if (!Equals(Console.OutputEncoding, Encoding.UTF8))
-            {
-                int written = Console.OutputEncoding.GetBytes($"\x1b[{y + 1};{x + 1}H", ansiBuffer);
-                buffer.Write(ansiBuffer[..written]);
-            }
-            else
-            {
-                // Performance optimization for Unicode
-                if (System.Text.Unicode.Utf8.TryWrite(ansiBuffer, $"\x1b[{y + 1};{x + 1}H", out int bytesWritten))
-                {
-                    buffer.Write(ansiBuffer[..bytesWritten]);
-                }
-            }
+            int written = Console.OutputEncoding.GetBytes($"\x1b[{y + 1};{x + 1}H", ansiBuffer);
+            buffer.Write(ansiBuffer[..written]);
         }
 
         private void WritePixelAnsi(Pixel p, in ArrayBufferWriter<byte> buffer)
@@ -628,10 +617,7 @@ namespace ConsoleRenderer
             }
 
             // 3. Write the character
-            if (Equals(Console.OutputEncoding, Encoding.UTF8))
-                WriteEncodedCharUtf8(buffer, p.Character);
-            else
-                WriteEncodedChar(buffer, p.Character);
+            WriteEncodedChar(buffer, p.Character);
         }
 
         private int CountCleanGap(int currentX, int rowOffset, int effectiveWidth)
@@ -684,35 +670,6 @@ namespace ConsoleRenderer
             Span<byte> dest = buffer.GetSpan(4);
             int written = Console.OutputEncoding.GetBytes(cSpan, dest);
             buffer.Advance(written);
-        }
-
-        // For performance testing
-
-        /// <summary>
-        /// Writing an encoded char in UTF can be done completely allocation free - no GC pressure at all.
-        /// Need to set Console.OutputEncoding = Encoding.UTF8;.
-        /// </summary>
-        /// <param name="buffer"></param>
-        /// <param name="c"></param>
-        private static void WriteEncodedCharUtf8(ArrayBufferWriter<byte> buffer, char c)
-        {
-            // 1. The ASCII Fast-Path: 90% of your TUI (ANSI codes, standard letters, numbers) 
-            // falls into this category. It completely skips the encoding engine.
-            if (c <= 127)
-            {
-                buffer.GetSpan(1)[0] = (byte)c;
-                buffer.Advance(1);
-                return;
-            }
-
-            // 2. The Unicode Path (Box drawing characters, symbols)
-            // System.Text.Rune is fast and guaranteed zero-allocation
-            var rune = new Rune(c);
-
-            // GetSpan(4) because a UTF-8 character is at most 4 bytes long
-            int bytesWritten = rune.EncodeToUtf8(buffer.GetSpan(4));
-
-            buffer.Advance(bytesWritten);
         }
     }
 }

--- a/ConsoleRenderer/ConsoleCanvas.cs
+++ b/ConsoleRenderer/ConsoleCanvas.cs
@@ -40,17 +40,22 @@ namespace ConsoleRenderer
 
         private const char _defaultCharacter = '*';
         private const char _emptyCharacter = ' ';
-        
+
         private int _previousWidth;
         private int _previousHeight;
         private bool _oddRows;
         private Pixel[] _pixels;
         private Pixel[] _previous;
-        
+
+        // Cached foregrounds and backgrounds to reduce writing ansi codes for repeated colors.
+        private int _lastFg;
+        private int _lastBg;
+
         /// <summary>
         ///     Shared across all instances so that every canvas renders to the same console output.
         /// </summary>
         private Stream? _outputStream;
+
         private ArrayBufferWriter<byte>? _frameBuffer;
 
         public ConsoleCanvas(int width, int height, bool interlaced = false, bool autoResize = false)
@@ -62,7 +67,7 @@ namespace ConsoleRenderer
 
             DefaultForegroundColor = Console.ForegroundColor;
             DefaultBackgroundColor = Console.BackgroundColor;
-            
+
             // In Linux Console.ForegroundColor is sometimes not defined (-1).
             // In that case set it manually.
             if ((int)DefaultForegroundColor == -1) DefaultForegroundColor = ConsoleColor.Gray;
@@ -74,7 +79,7 @@ namespace ConsoleRenderer
             Resize(width, height);
         }
 
-        public ConsoleCanvas(bool interlaced = false, bool autoResize = false) 
+        public ConsoleCanvas(bool interlaced = false, bool autoResize = false)
             : this(Console.WindowWidth, Console.WindowHeight, interlaced, autoResize)
         {
         }
@@ -139,7 +144,8 @@ namespace ConsoleRenderer
         /// <param name="character">Character to draw the border with, or <see cref="null"/> to use default pretty borders</param>
         public ConsoleCanvas CreateBorder(int startX, int startY, int width, int height, char? character = null)
         {
-            return CreateBorder(startX, startY, width, height, character, DefaultForegroundColor, DefaultBackgroundColor);
+            return CreateBorder(startX, startY, width, height, character, DefaultForegroundColor,
+                DefaultBackgroundColor);
         }
 
         /// <summary>
@@ -153,7 +159,8 @@ namespace ConsoleRenderer
         /// <param name="foreground">Color to draw the border with</param>
         /// <param name="background">Color to draw the border with</param>
         /// <returns></returns>
-        public ConsoleCanvas CreateBorder(int startX, int startY, int width, int height, char? character, ConsoleColor foreground, ConsoleColor background)
+        public ConsoleCanvas CreateBorder(int startX, int startY, int width, int height, char? character,
+            ConsoleColor foreground, ConsoleColor background)
         {
             int endX = startX + width - 1;
             int endY = startY + height - 1;
@@ -197,12 +204,14 @@ namespace ConsoleRenderer
                 if (onRight) return '╗';
                 return '═';
             }
+
             if (onBottom)
             {
                 if (onLeft) return '╚';
                 if (onRight) return '╝';
                 return '═';
             }
+
             if (onLeft || onRight) return '║';
             return _emptyCharacter;
         }
@@ -215,9 +224,11 @@ namespace ConsoleRenderer
         /// <param name="width">Width of the rectangle</param>
         /// <param name="height">Height of the rectangle</param>
         /// <param name="character">Character to fill the rectangle with</param>
-        public ConsoleCanvas CreateRectangle(int startX, int startY, int width, int height, char character = _defaultCharacter)
+        public ConsoleCanvas CreateRectangle(int startX, int startY, int width, int height,
+            char character = _defaultCharacter)
         {
-            return CreateRectangle(startX, startY, width, height, character, DefaultForegroundColor, DefaultBackgroundColor);
+            return CreateRectangle(startX, startY, width, height, character, DefaultForegroundColor,
+                DefaultBackgroundColor);
         }
 
         /// <summary>
@@ -230,7 +241,8 @@ namespace ConsoleRenderer
         /// <param name="character">Character to fill the rectangle with</param>
         /// <param name="foreground">Color to draw the character with</param>
         /// <param name="background">Color to draw the background with</param>
-        public ConsoleCanvas CreateRectangle(int startX, int startY, int width, int height, char character, ConsoleColor foreground, ConsoleColor background)
+        public ConsoleCanvas CreateRectangle(int startX, int startY, int width, int height, char character,
+            ConsoleColor foreground, ConsoleColor background)
         {
             int yMin = Math.Max(0, startY);
             int yMax = Math.Min(Height, startY + height);
@@ -262,7 +274,7 @@ namespace ConsoleRenderer
 
             int windowWidth = Console.WindowWidth;
             int windowHeight = Console.WindowHeight;
-            bool isSizeChanged = _previousWidth!= windowWidth || _previousHeight!= windowHeight;
+            bool isSizeChanged = _previousWidth != windowWidth || _previousHeight != windowHeight;
 
             if (isSizeChanged)
             {
@@ -286,8 +298,8 @@ namespace ConsoleRenderer
                 FullRedraw(effectiveWidth, effectiveHeight, buffer);
             }
             else
-            { 
-                // We do NOT write 1;1 here. RenderCluster handles its own positioning.
+            {
+                // We do not write 1;1 here. RenderCluster handles its own positioning.
                 // Perform sparse update
                 for (int y = 0; y < effectiveHeight; y++)
                 {
@@ -307,7 +319,7 @@ namespace ConsoleRenderer
                     }
                 }
             }
-            
+
             _outputStream!.Write(buffer.WrittenSpan);
             _outputStream.Flush();
             // After rendering, sync the buffers so we know what to diff next time
@@ -463,7 +475,8 @@ namespace ConsoleRenderer
         /// <param name="centered">Whether the text should be centered around the <paramref name="x"/> coordinate</param>
         /// <param name="foreground">Foreground color to draw the string with, or <see cref="DefaultForegroundColor"/> if <see cref="null"/></param>
         /// <param name="background">Background color to draw the string with, or <see cref="DefaultBackgroundColor"/> if <see cref="null"/></param>
-        public ConsoleCanvas Text(int x, int y, string text, bool centered = false, ConsoleColor? foreground = null, ConsoleColor? background = null)
+        public ConsoleCanvas Text(int x, int y, string text, bool centered = false, ConsoleColor? foreground = null,
+            ConsoleColor? background = null)
         {
             // If the text should be centered, deduct half the text length from the x coordinate
             int startX = centered ? x - (int)Math.Floor(text.Length / 2d) : x;
@@ -497,9 +510,10 @@ namespace ConsoleRenderer
         /// <exception cref="IndexOutOfRangeException"></exception>
         public Pixel Get(int x, int y, bool backBuffer = true)
         {
-            if ( x < 0 || y < 0 || x >= Width || y >= Height)
+            if (x < 0 || y < 0 || x >= Width || y >= Height)
             {
-                throw new IndexOutOfRangeException($"The coordinates {x},{y} need to be positive and less than {Width} and {Height}");
+                throw new IndexOutOfRangeException(
+                    $"The coordinates {x},{y} need to be positive and less than {Width} and {Height}");
             }
 
             int index = y * Width + x;
@@ -525,7 +539,7 @@ namespace ConsoleRenderer
                 return;
 
             WindowsAnsi.EnsureAnsiSupport();
-                
+
             if (_outputStream == null)
                 _outputStream = Console.OpenStandardOutput();
 
@@ -542,53 +556,34 @@ namespace ConsoleRenderer
         /// <param name="buffer">Buffer to draw into (stream the ansi codes).</param>
         private void FullRedraw(int effectiveWidth, int effectiveHeight, in ArrayBufferWriter<byte> buffer)
         {
-            int lastFg = -1;
-            int lastBg = -1;
+            _lastFg = -1;
+            _lastBg = -1;
             for (int y = 0; y < effectiveHeight; y++)
             {
                 bool skipRow = Interlaced && ((_oddRows && y % 2 == 0) || (!_oddRows && y % 2 != 0));
                 ReadOnlySpan<Pixel> source = skipRow ? _previous : _pixels;
                 int indexOffset = y * Width;
-                
+
                 for (int x = 0; x < effectiveWidth; x++)
                 {
                     Pixel p = source[indexOffset + x];
-                    int fg = AnsiForeground[(int)p.Foreground];
-                    int bg = AnsiBackground[(int)p.Background];
-
-                    if (fg != lastFg || bg != lastBg)
-                    {
-                        WriteSgr(buffer, fg);
-                        WriteSgr(buffer, bg);
-                        lastFg = fg;
-                        lastBg = bg;
-                    }
-
-                    if (Equals(Console.OutputEncoding, Encoding.UTF8))
-                    {
-                        WriteEncodedCharUtf8(buffer, p.Character);
-                    }
-                    else
-                    {
-                        WriteEncodedChar(buffer, p.Character);
-                    }
+                    WritePixelAnsi(p, buffer);
                 }
 
                 // Newline between rows only; skipping after last row prevents terminal scroll (first line cut off)
                 if (y < effectiveHeight - 1)
                     buffer.Write("\n"u8);
-                
-                lastFg = -1;
-                lastBg = -1;
 
-                if (!skipRow)
-                {
-                    for (int x = 0; x < Width; x++)
-                        _previous[indexOffset + x] = source[indexOffset + x];
-                }
+                _lastFg = -1;
+                _lastBg = -1;
+
+                if (skipRow) continue;
+
+                for (int x = 0; x < Width; x++)
+                    _previous[indexOffset + x] = source[indexOffset + x];
             }
         }
-        
+
         /// <summary>
         /// Renders a cluster of changed pixels.
         /// If there is a gap of a clean pixels in-between dirty pixels, one of two options will happen:
@@ -609,60 +604,80 @@ namespace ConsoleRenderer
         {
             int currentX = startX;
             int rowOffset = y * Width;
-            int lastFg = -1;
-            int lastBg = -1;
+            _lastFg = -1;
+            _lastBg = -1;
 
             // 1. Move Cursor (Note the +1 for 1-based terminal coords)
-            Span<byte> ansiBuffer = stackalloc byte[32];
-            if (System.Text.Unicode.Utf8.TryWrite(ansiBuffer, $"\x1b[{y + 1};{startX + 1}H", out int bytesWritten))
-            {
-                buffer.Write(ansiBuffer[..bytesWritten]);
-            }
+            MoveCursorAnsi(currentX, y, buffer);
 
             while (currentX < effectiveWidth)
             {
                 int index = rowOffset + currentX;
                 Pixel p = _pixels[index];
+                WritePixelAnsi(p, buffer);
 
-                // 2. State-aware Color Update
-                int fg = AnsiForeground[(int)p.Foreground];
-                int bg = AnsiBackground[(int)p.Background];
-
-                if (fg != lastFg) { WriteSgr(buffer, fg); lastFg = fg; }
-                if (bg != lastBg) { WriteSgr(buffer, bg); lastBg = bg; }
-
-                // 3. Write the character
-                if (Equals(Console.OutputEncoding, Encoding.UTF8))
-                {
-                    WriteEncodedCharUtf8(buffer, p.Character);
-                }
-                else
-                {
-                    WriteEncodedChar(buffer, p.Character);
-                }
-                
                 currentX++;
-
-                // 4. Look Ahead Logic
-                if (currentX < effectiveWidth)
-                {
-                    int nextIndex = rowOffset + currentX;
-                    // If the next pixel is clean (unchanged)...
-                    if (_pixels[nextIndex] == _previous[nextIndex])
-                    {
-                        int gapSize = CountCleanGap(currentX, rowOffset, effectiveWidth);
+                if (currentX >= effectiveWidth) continue;
                 
-                        // If gap is too big, stop this cluster and jump later
-                        if (gapSize > 6) break; 
+                // 4. Look Ahead Logic
+                int nextIndex = rowOffset + currentX;
+                    
+                if (_pixels[nextIndex] != _previous[nextIndex]) continue;
+                // If the next pixel is clean (unchanged), then start counting the gap
+                int gapSize = CountCleanGap(currentX, rowOffset, effectiveWidth);
+                // If gap is too big, stop this cluster and jump later
+                if (gapSize > 6) break;
 
-                        // Otherwise, the loop just continues naturally.
-                        // The next iteration will "overdraw" the clean pixels.
-                    }
-                }
+                // Otherwise, the loop just continues naturally.
+                // The next iteration will "overdraw" the clean pixels.
             }
+
             return currentX;
         }
-        
+
+        private void MoveCursorAnsi(int x, int y, in ArrayBufferWriter<byte> buffer)
+        {
+            Span<byte> ansiBuffer = stackalloc byte[32];
+            if (!Equals(Console.OutputEncoding, Encoding.UTF8))
+            {
+                int written = Console.OutputEncoding.GetBytes($"\x1b[{y + 1};{x + 1}H", ansiBuffer);
+                buffer.Write(ansiBuffer[..written]);
+            }
+            else
+            {
+                // Performance optimization for Unicode
+                if (System.Text.Unicode.Utf8.TryWrite(ansiBuffer, $"\x1b[{y + 1};{x + 1}H", out int bytesWritten))
+                {
+                    buffer.Write(ansiBuffer[..bytesWritten]);
+                }
+            }
+        }
+
+        private void WritePixelAnsi(Pixel p, in ArrayBufferWriter<byte> buffer)
+        {
+            // 2. State-aware Color Update
+            int fg = AnsiForeground[(int)p.Foreground];
+            int bg = AnsiBackground[(int)p.Background];
+
+            if (fg != _lastFg)
+            {
+                WriteSgr(buffer, fg);
+                _lastFg = fg;
+            }
+
+            if (bg != _lastBg)
+            {
+                WriteSgr(buffer, bg);
+                _lastBg = bg;
+            }
+
+            // 3. Write the character
+            if (Equals(Console.OutputEncoding, Encoding.UTF8))
+                WriteEncodedCharUtf8(buffer, p.Character);
+            else
+                WriteEncodedChar(buffer, p.Character);
+        }
+
         private int CountCleanGap(int currentX, int rowOffset, int effectiveWidth)
         {
             int gapSize = 0;
@@ -679,10 +694,13 @@ namespace ConsoleRenderer
 
             return gapSize;
         }
-        
+
         // ANSI SGR codes for ConsoleColor (index = (int)ConsoleColor): 30-37, 90-97 fg; 40-47, 100-107 bg
-        private static readonly int[] AnsiForeground = { 30, 34, 32, 36, 31, 35, 33, 37, 90, 94, 92, 96, 91, 95, 93, 97 };
-        private static readonly int[] AnsiBackground = { 40, 44, 42, 46, 41, 45, 43, 47, 100, 104, 102, 106, 101, 105, 103, 107 };
+        private static readonly int[] AnsiForeground =
+            { 30, 34, 32, 36, 31, 35, 33, 37, 90, 94, 92, 96, 91, 95, 93, 97 };
+
+        private static readonly int[] AnsiBackground =
+            { 40, 44, 42, 46, 41, 45, 43, 47, 100, 104, 102, 106, 101, 105, 103, 107 };
 
         private static void WriteSgr(ArrayBufferWriter<byte> buffer, int code)
         {
@@ -700,6 +718,7 @@ namespace ConsoleRenderer
             {
                 buffer.Write(stackalloc byte[] { (byte)('0' + code) });
             }
+
             buffer.Write("m"u8);
         }
 
@@ -710,9 +729,9 @@ namespace ConsoleRenderer
             int written = Console.OutputEncoding.GetBytes(cSpan, dest);
             buffer.Advance(written);
         }
-        
+
         // For performance testing
-        
+
         /// <summary>
         /// Writing an encoded char in UTF can be done completely allocation free - no GC pressure at all.
         /// Need to set Console.OutputEncoding = Encoding.UTF8;.
@@ -733,10 +752,10 @@ namespace ConsoleRenderer
             // 2. The Unicode Path (Box drawing characters, symbols)
             // System.Text.Rune is fast and guaranteed zero-allocation
             var rune = new Rune(c);
-    
+
             // GetSpan(4) because a UTF-8 character is at most 4 bytes long
             int bytesWritten = rune.EncodeToUtf8(buffer.GetSpan(4));
-    
+
             buffer.Advance(bytesWritten);
         }
     }

--- a/ConsoleRenderer/ConsoleCanvas.cs
+++ b/ConsoleRenderer/ConsoleCanvas.cs
@@ -144,8 +144,7 @@ namespace ConsoleRenderer
         /// <param name="character">Character to draw the border with, or <see cref="null"/> to use default pretty borders</param>
         public ConsoleCanvas CreateBorder(int startX, int startY, int width, int height, char? character = null)
         {
-            return CreateBorder(startX, startY, width, height, character, DefaultForegroundColor,
-                DefaultBackgroundColor);
+            return CreateBorder(startX, startY, width, height, character, DefaultForegroundColor, DefaultBackgroundColor);
         }
 
         /// <summary>
@@ -159,8 +158,7 @@ namespace ConsoleRenderer
         /// <param name="foreground">Color to draw the border with</param>
         /// <param name="background">Color to draw the border with</param>
         /// <returns></returns>
-        public ConsoleCanvas CreateBorder(int startX, int startY, int width, int height, char? character,
-            ConsoleColor foreground, ConsoleColor background)
+        public ConsoleCanvas CreateBorder(int startX, int startY, int width, int height, char? character, ConsoleColor foreground, ConsoleColor background)
         {
             int endX = startX + width - 1;
             int endY = startY + height - 1;

--- a/ConsoleRenderer/ConsoleCanvas.cs
+++ b/ConsoleRenderer/ConsoleCanvas.cs
@@ -261,16 +261,13 @@ namespace ConsoleRenderer
 
             int windowWidth = Console.WindowWidth;
             int windowHeight = Console.WindowHeight;
+            bool isSizeChanged = _previousWidth!= windowWidth || _previousHeight!= windowHeight;
 
-            if (_previousWidth != windowWidth || _previousHeight != windowHeight)
+            if (isSizeChanged)
             {
-                if (AutoResize)
-                {
-                    Resize(windowWidth, windowHeight);
-                }
+                if (AutoResize) Resize(windowWidth, windowHeight);
 
                 ClearPixelCache();
-
                 _previousWidth = windowWidth;
                 _previousHeight = windowHeight;
             }
@@ -281,54 +278,39 @@ namespace ConsoleRenderer
             ArrayBufferWriter<byte> buffer = _frameBuffer!;
             buffer.Clear();
 
-            // Cursor to top-left (1-based in ANSI)
-            buffer.Write("\x1b[1;1H"u8);
-
-            int lastFg = -1;
-            int lastBg = -1;
-
-            for (int y = 0; y < effectiveHeight; y++)
+            if (isSizeChanged)
             {
-                bool skipRow = Interlaced && ((_oddRows && y % 2 == 0) || (!_oddRows && y % 2 != 0));
-                ReadOnlySpan<Pixel> source = skipRow ? _previous : _pixels;
-
-                for (int x = 0; x < effectiveWidth; x++)
+                // Cursor to top-left (1-based in ANSI)
+                buffer.Write("\x1b[1;1H"u8);
+                FullRedraw(effectiveWidth, effectiveHeight, buffer);
+            }
+            else
+            { 
+                // We do NOT write 1;1 here. RenderCluster handles its own positioning.
+                // Perform sparse update
+                for (int y = 0; y < effectiveHeight; y++)
                 {
-                    Pixel p = source[y * Width + x];
-                    int fg = AnsiForeground[(int)p.Foreground];
-                    int bg = AnsiBackground[(int)p.Background];
+                    bool skipRow = Interlaced && ((_oddRows && y % 2 == 0) || (!_oddRows && y % 2 != 0));
+                    if (skipRow) continue;
 
-                    if (fg != lastFg || bg != lastBg)
+                    for (int x = 0; x < effectiveWidth; x++)
                     {
-                        WriteSgr(buffer, fg);
-                        WriteSgr(buffer, bg);
-                        lastFg = fg;
-                        lastBg = bg;
+                        int idx = y * Width + x;
+                        if (_pixels[idx] != _previous[idx])
+                        {
+                            // Found a 'dirty' pixel.
+                            // Start a cluster: look ahead in this row to see whether we should over-draw
+                            // or jump to the next cluster.
+                            x = RenderCluster(effectiveWidth, x, y, buffer);
+                        }
                     }
-
-                    WriteEncodedChar(buffer, p.Character);
-                }
-
-                // Newline between rows only; skipping after last row prevents terminal scroll (first line cut off)
-                if (y < effectiveHeight - 1)
-                    buffer.Write("\n"u8);
-                
-                lastFg = -1;
-                lastBg = -1;
-
-                if (!skipRow)
-                {
-                    int rowStart = y * Width;
-                    for (int x = 0; x < Width; x++)
-                        _previous[rowStart + x] = source[rowStart + x];
                 }
             }
-
-            // Cursor to top-left (1-based in ANSI)
-            buffer.Write("\x1b[1;1H"u8);
             
             _outputStream!.Write(buffer.WrittenSpan);
             _outputStream.Flush();
+            // After rendering, sync the buffers so we know what to diff next time
+            _pixels.CopyTo(_previous);
 
             _oddRows = !_oddRows;
             return this;
@@ -550,6 +532,138 @@ namespace ConsoleRenderer
                 _frameBuffer = new ArrayBufferWriter<byte>();
         }
 
+        /// <summary>
+        /// Fully redraws the entire window.
+        /// Recommended to use only after resize.
+        /// </summary>
+        /// <param name="effectiveWidth">Width of the buffer to draw.</param>
+        /// <param name="effectiveHeight">Height of the buffer to draw.</param>
+        /// <param name="buffer">Buffer to draw into (stream the ansi codes).</param>
+        private void FullRedraw(int effectiveWidth, int effectiveHeight, in ArrayBufferWriter<byte> buffer)
+        {
+            int lastFg = -1;
+            int lastBg = -1;
+            for (int y = 0; y < effectiveHeight; y++)
+            {
+                bool skipRow = Interlaced && ((_oddRows && y % 2 == 0) || (!_oddRows && y % 2 != 0));
+                ReadOnlySpan<Pixel> source = skipRow ? _previous : _pixels;
+                int indexOffset = y * Width;
+                
+                for (int x = 0; x < effectiveWidth; x++)
+                {
+                    Pixel p = source[indexOffset + x];
+                    int fg = AnsiForeground[(int)p.Foreground];
+                    int bg = AnsiBackground[(int)p.Background];
+
+                    if (fg != lastFg || bg != lastBg)
+                    {
+                        WriteSgr(buffer, fg);
+                        WriteSgr(buffer, bg);
+                        lastFg = fg;
+                        lastBg = bg;
+                    }
+
+                    WriteEncodedChar(buffer, p.Character);
+                }
+
+                // Newline between rows only; skipping after last row prevents terminal scroll (first line cut off)
+                if (y < effectiveHeight - 1)
+                    buffer.Write("\n"u8);
+                
+                lastFg = -1;
+                lastBg = -1;
+
+                if (!skipRow)
+                {
+                    for (int x = 0; x < Width; x++)
+                        _previous[indexOffset + x] = source[indexOffset + x];
+                }
+            }
+        }
+        
+        /// <summary>
+        /// Renders a cluster of changed pixels.
+        /// If there is a gap of a clean pixels in-between dirty pixels, one of two options will happen:
+        /// - re-render it if the gap is sufficiently small
+        /// - finish the cluster, skip the gap and start a new cluster if the clean gap is too small.
+        /// </summary>
+        /// <param name="effectiveWidth">Width of the window to render.</param>
+        /// <param name="startX">Current position in the row to render.</param>
+        /// <param name="y">Row.</param>
+        /// <param name="source">Source buffer to draw from.</param>
+        /// <param name="buffer">Writer to stream the Ansi code bytes to.</param>
+        /// <returns>New position of X after the cluster has been rendered.</returns>
+        private int RenderCluster(
+            int effectiveWidth,
+            int startX,
+            int y,
+            in ArrayBufferWriter<byte> buffer)
+        {
+            int currentX = startX;
+            int rowOffset = y * Width;
+            int lastFg = -1;
+            int lastBg = -1;
+
+            // 1. Move Cursor (Note the +1 for 1-based terminal coords)
+            Span<byte> ansiBuffer = stackalloc byte[32];
+            if (System.Text.Unicode.Utf8.TryWrite(ansiBuffer, $"\x1b[{y + 1};{startX + 1}H", out int bytesWritten))
+            {
+                buffer.Write(ansiBuffer[..bytesWritten]);
+            }
+
+            while (currentX < effectiveWidth)
+            {
+                int index = rowOffset + currentX;
+                Pixel p = _pixels[index];
+
+                // 2. State-aware Color Update
+                int fg = AnsiForeground[(int)p.Foreground];
+                int bg = AnsiBackground[(int)p.Background];
+
+                if (fg != lastFg) { WriteSgr(buffer, fg); lastFg = fg; }
+                if (bg != lastBg) { WriteSgr(buffer, bg); lastBg = bg; }
+
+                // 3. Write the character
+                WriteEncodedChar(buffer, p.Character);
+                currentX++;
+
+                // 4. Look Ahead Logic
+                if (currentX < effectiveWidth)
+                {
+                    int nextIndex = rowOffset + currentX;
+                    // If the next pixel is clean (unchanged)...
+                    if (_pixels[nextIndex] == _previous[nextIndex])
+                    {
+                        int gapSize = CountCleanGap(currentX, rowOffset, effectiveWidth);
+                
+                        // If gap is too big, stop this cluster and jump later
+                        if (gapSize > 6) break; 
+
+                        // Otherwise, the loop just continues naturally.
+                        // The next iteration will "overdraw" the clean pixels.
+                    }
+                }
+            }
+            return currentX;
+        }
+        
+        private int CountCleanGap(int currentX, int rowOffset, int effectiveWidth)
+        {
+            int gapSize = 0;
+            for (int x = currentX; x < effectiveWidth; x++)
+            {
+                int index = rowOffset + x;
+                if (_pixels[index] != _previous[index])
+                {
+                    return gapSize;
+                }
+
+                gapSize++;
+            }
+
+            return gapSize;
+        }
+        
         // ANSI SGR codes for ConsoleColor (index = (int)ConsoleColor): 30-37, 90-97 fg; 40-47, 100-107 bg
         private static readonly int[] AnsiForeground = { 30, 34, 32, 36, 31, 35, 33, 37, 90, 94, 92, 96, 91, 95, 93, 97 };
         private static readonly int[] AnsiBackground = { 40, 44, 42, 46, 41, 45, 43, 47, 100, 104, 102, 106, 101, 105, 103, 107 };

--- a/ConsoleRenderer/ConsoleCanvas.cs
+++ b/ConsoleRenderer/ConsoleCanvas.cs
@@ -2,6 +2,7 @@ using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 
 namespace ConsoleRenderer
 {
@@ -563,7 +564,14 @@ namespace ConsoleRenderer
                         lastBg = bg;
                     }
 
-                    WriteEncodedChar(buffer, p.Character);
+                    if (Equals(Console.OutputEncoding, Encoding.UTF8))
+                    {
+                        WriteEncodedCharUtf8(buffer, p.Character);
+                    }
+                    else
+                    {
+                        WriteEncodedChar(buffer, p.Character);
+                    }
                 }
 
                 // Newline between rows only; skipping after last row prevents terminal scroll (first line cut off)
@@ -624,7 +632,15 @@ namespace ConsoleRenderer
                 if (bg != lastBg) { WriteSgr(buffer, bg); lastBg = bg; }
 
                 // 3. Write the character
-                WriteEncodedChar(buffer, p.Character);
+                if (Equals(Console.OutputEncoding, Encoding.UTF8))
+                {
+                    WriteEncodedCharUtf8(buffer, p.Character);
+                }
+                else
+                {
+                    WriteEncodedChar(buffer, p.Character);
+                }
+                
                 currentX++;
 
                 // 4. Look Ahead Logic
@@ -693,6 +709,35 @@ namespace ConsoleRenderer
             Span<byte> dest = buffer.GetSpan(4);
             int written = Console.OutputEncoding.GetBytes(cSpan, dest);
             buffer.Advance(written);
+        }
+        
+        // For performance testing
+        
+        /// <summary>
+        /// Writing an encoded char in UTF can be done completely allocation free - no GC pressure at all.
+        /// Need to set Console.OutputEncoding = Encoding.UTF8;.
+        /// </summary>
+        /// <param name="buffer"></param>
+        /// <param name="c"></param>
+        private static void WriteEncodedCharUtf8(ArrayBufferWriter<byte> buffer, char c)
+        {
+            // 1. The ASCII Fast-Path: 90% of your TUI (ANSI codes, standard letters, numbers) 
+            // falls into this category. It completely skips the encoding engine.
+            if (c <= 127)
+            {
+                buffer.GetSpan(1)[0] = (byte)c;
+                buffer.Advance(1);
+                return;
+            }
+
+            // 2. The Unicode Path (Box drawing characters, symbols)
+            // System.Text.Rune is fast and guaranteed zero-allocation
+            var rune = new Rune(c);
+    
+            // GetSpan(4) because a UTF-8 character is at most 4 bytes long
+            int bytesWritten = rune.EncodeToUtf8(buffer.GetSpan(4));
+    
+            buffer.Advance(bytesWritten);
         }
     }
 }

--- a/ConsoleRenderer/ConsoleCanvas.cs
+++ b/ConsoleRenderer/ConsoleCanvas.cs
@@ -291,31 +291,24 @@ namespace ConsoleRenderer
             ArrayBufferWriter<byte> buffer = _frameBuffer!;
             buffer.Clear();
 
-            if (isSizeChanged)
+            buffer.Write("\x1b[1;1H"u8);
+            // We do not write 1;1 here. RenderCluster handles its own positioning.
+            // Perform sparse update
+            for (int y = 0; y < effectiveHeight; y++)
             {
-                // Cursor to top-left (1-based in ANSI)
-                buffer.Write("\x1b[1;1H"u8);
-                FullRedraw(effectiveWidth, effectiveHeight, buffer);
-            }
-            else
-            {
-                // We do not write 1;1 here. RenderCluster handles its own positioning.
-                // Perform sparse update
-                for (int y = 0; y < effectiveHeight; y++)
-                {
-                    bool skipRow = Interlaced && ((_oddRows && y % 2 == 0) || (!_oddRows && y % 2 != 0));
-                    if (skipRow) continue;
+                bool skipRow =
+                    Interlaced && ((_oddRows && y % 2 == 0) || (!_oddRows && y % 2 != 0));
+                if (skipRow) continue;
 
-                    for (int x = 0; x < effectiveWidth; x++)
+                for (int x = 0; x < effectiveWidth; x++)
+                {
+                    int idx = y * Width + x;
+                    if (_pixels[idx] != _previous[idx])
                     {
-                        int idx = y * Width + x;
-                        if (_pixels[idx] != _previous[idx])
-                        {
-                            // Found a 'dirty' pixel.
-                            // Start a cluster: look ahead in this row to see whether we should over-draw
-                            // or jump to the next cluster.
-                            x = RenderCluster(effectiveWidth, x, y, buffer);
-                        }
+                        // Found a 'dirty' pixel.
+                        // Start a cluster: look ahead in this row to see whether we should over-draw
+                        // or jump to the next cluster.
+                        x = RenderCluster(effectiveWidth, x, y, buffer);
                     }
                 }
             }
@@ -545,43 +538,6 @@ namespace ConsoleRenderer
 
             if (_frameBuffer == null)
                 _frameBuffer = new ArrayBufferWriter<byte>();
-        }
-
-        /// <summary>
-        /// Fully redraws the entire window.
-        /// Recommended to use only after resize.
-        /// </summary>
-        /// <param name="effectiveWidth">Width of the buffer to draw.</param>
-        /// <param name="effectiveHeight">Height of the buffer to draw.</param>
-        /// <param name="buffer">Buffer to draw into (stream the ansi codes).</param>
-        private void FullRedraw(int effectiveWidth, int effectiveHeight, in ArrayBufferWriter<byte> buffer)
-        {
-            _lastFg = -1;
-            _lastBg = -1;
-            for (int y = 0; y < effectiveHeight; y++)
-            {
-                bool skipRow = Interlaced && ((_oddRows && y % 2 == 0) || (!_oddRows && y % 2 != 0));
-                ReadOnlySpan<Pixel> source = skipRow ? _previous : _pixels;
-                int indexOffset = y * Width;
-
-                for (int x = 0; x < effectiveWidth; x++)
-                {
-                    Pixel p = source[indexOffset + x];
-                    WritePixelAnsi(p, buffer);
-                }
-
-                // Newline between rows only; skipping after last row prevents terminal scroll (first line cut off)
-                if (y < effectiveHeight - 1)
-                    buffer.Write("\n"u8);
-
-                _lastFg = -1;
-                _lastBg = -1;
-
-                if (skipRow) continue;
-
-                for (int x = 0; x < Width; x++)
-                    _previous[indexOffset + x] = source[indexOffset + x];
-            }
         }
 
         /// <summary>


### PR DESCRIPTION
# Clustered Rendering

Hi, it's me again. After the last PR I did some research on how to best re-enable double buffered rendering where the current and previous buffers are compared and only the difference is rendered.

My initial idea was to compare both buffers and if the difference between is larger than a certain percentage then everything is re-rendered, otherwise just the difference. This would run in O(2n) because we iterate twice over the buffers: once for comparison and once for rendering.

Then I found the so-called clustered rendering. This works with a single pass over both buffers and clustering all differing cells as close as possible to minimise cursor repositioning via ansi codes. That means a row of dirty cells is rendered as one cluster even if there are some clean cells in-between as long as the 'clean gap' is smaller than 6. This value can be tweaked but is supposed to be a good heuristic for finding a middle ground between over-rendering and repositioning.

For Pong (the best case for testing sparse rendering) in a fixed testing window of 120x30 characters I have ~4000 FPS with the main branch and ~14000 FPS with this feature branch on both Linux and Windows.

## Importance of Encoding

While testing on both systems I found an interesting thing about encoding. The above-mentioned speeds I can only reproduce on Windows when setting `Console.OutputEncoding` to UTF-8. There seems to be some optimization because for UTF-8 there are zero heap allocations during rendering, resulting in zero garbage collection. However, when not setting `Console.OutputEncoding` then there are heap allocations (probably because of boxing) and the GC pressure is quite high, resulting in a drastic slowdown.

Under Linux this doesn't happen. I'm unable to provoke any GC activity here. This could explain some disparity between Windows and Linux performance when in fact both can be equally fast actually.

While I did try to implement some UTF-8 specific optimization ( see method `WriteEndcodedCharUtf8()`) this does not seem to be necessary and can be deleted. I did this before checking the encoding and UTF-8 seems to be always allocation-free even without using the UTF-8 specific method. Unless you spot a difference during testing I'll take it out later to keep the code a bit leaner.

---

Hope you don't feel swamped by this recent activity. I felt compelled to shared this improvement because having this jump in FPS for sparse rendering, combined with completely allocation-free rendering with zero GC pressure is so satisfying every time I see it in the profiler :)
As always no rush! Second opinions and critique are more than welcome.

Thanks for taking the time.